### PR TITLE
Fix dup write wait problems when tcp streamed

### DIFF
--- a/src/server-session.c
+++ b/src/server-session.c
@@ -55,6 +55,19 @@ server_sess_wait_for_event(server_session_t *ss, short ev_type, struct timeval *
 }
 
 static void
+remove_server_wait_event(network_mysqld_con *con)
+{
+    int i;
+    for (i = 0; i < con->servers->len; i++) {
+        server_session_t *ss = (server_session_t *)g_ptr_array_index(con->servers, i);
+        network_socket *server = ss->server;
+        if (server->is_waiting) {
+            CHECK_PENDING_EVENT(&(server->event));
+        }
+    }
+}
+
+static void
 do_tcp_stream_after_recv_resp(network_mysqld_con *con, server_session_t *ss)
 {
     merge_parameters_t *data = con->data;
@@ -97,6 +110,7 @@ do_tcp_stream_after_recv_resp(network_mysqld_con *con, server_session_t *ss)
             }
         }
     } else {
+        remove_server_wait_event(con);
         g_message("%s: resp too long:%p, src port:%s, sql:%s",
                   G_STRLOC, con, con->client->src->name->str, con->orig_sql->str);
         network_mysqld_con_send_error_full(con->client, C("response too long for proxy"), ER_CETUS_LONG_RESP, "HY000");


### PR DESCRIPTION
解决高延迟场景下，过大响应可能会导致重复设置写事件，从而导致libevent cpu 100%问题