### PR TITLE
Add options for client idle timeout

### DIFF
--- a/plugins/proxy/proxy-plugin.c
+++ b/plugins/proxy/proxy-plugin.c
@@ -141,7 +141,7 @@ NETWORK_MYSQLD_PLUGIN_PROTO(proxy_timeout)
     g_debug("%s, con:%p:call proxy_timeout", G_STRLOC, con);
     switch (con->state) {
     case ST_READ_QUERY:
-        if (diff < 8 * HOURS) {
+        if (diff < con->srv->client_idle_timeout) {
             if (con->server && !con->client->is_server_conn_reserved) {
                 if (network_pool_add_conn(con, 0) != 0) {
                     g_debug("%s, con:%p:conn to pool failed", G_STRLOC, con);
@@ -155,7 +155,7 @@ NETWORK_MYSQLD_PLUGIN_PROTO(proxy_timeout)
         }
         break;
     case ST_READ_QUERY_RESULT:
-        if (diff < 8 * HOURS) {
+        if (diff < con->srv->client_idle_timeout) {
             if (con->server && !con->client->is_server_conn_reserved) {
                 con->server_to_be_closed = 1;
                 g_critical("%s, con:%p read query result timeout, sql:%s", G_STRLOC, con, con->orig_sql->str);
@@ -171,7 +171,7 @@ NETWORK_MYSQLD_PLUGIN_PROTO(proxy_timeout)
         }
         break;
     default:
-        if (diff >= 8 * HOURS) {
+        if (diff >= con->srv->client_idle_timeout) {
             con->prev_state = con->state;
             con->state = ST_SEND_ERROR;
         }

--- a/plugins/shard/shard-plugin.c
+++ b/plugins/shard/shard-plugin.c
@@ -121,7 +121,7 @@ NETWORK_MYSQLD_PLUGIN_PROTO(proxy_timeout)
         break;
     default:
         diff = time(0) - con->client->create_or_update_time;
-        if (diff < 8 * HOURS) {
+        if (diff < con->srv->client_idle_timeout) {
             if (!con->client->is_server_conn_reserved) {
                 g_debug("%s, is_server_conn_reserved is false", G_STRLOC);
                 if (con->servers && con->servers->len > 0) {

--- a/src/chassis-mainloop.h
+++ b/src/chassis-mainloop.h
@@ -136,6 +136,7 @@ struct chassis {
     unsigned int check_slave_delay;
     int complement_conn_cnt;
     int default_query_cache_timeout;
+    int client_idle_timeout;
     double slave_delay_down_threshold_sec;
     double slave_delay_recover_threshold_sec;
     unsigned int long_query_time;

--- a/src/chassis-options-utils.c
+++ b/src/chassis-options-utils.c
@@ -18,6 +18,7 @@
 
  $%ENDLICENSE%$ */
 
+#include "chassis-timings.h"
 #include "chassis-options-utils.h"
 #include "chassis-plugin.h"
 #include "cetus-util.h"
@@ -845,6 +846,49 @@ assign_default_query_cache_timeout(const gchar *newval, gpointer param) {
             if(try_get_int_value(newval, &value)) {
                 if(value >= 0) {
                     srv->default_query_cache_timeout = value;
+                    ret = ASSIGN_OK;
+                } else {
+                    ret = ASSIGN_VALUE_INVALID;
+                }
+            } else {
+                ret = ASSIGN_VALUE_INVALID;
+            }
+        } else {
+            ret = ASSIGN_VALUE_INVALID;
+        }
+    }
+    return ret;
+}
+
+gchar*
+show_default_client_idle_timeout(gpointer param) {
+    struct external_param *opt_param = (struct external_param *)param;
+    chassis *srv = opt_param->chas;
+    gint opt_type = opt_param->opt_type;
+    if(CAN_SHOW_OPTS_PROPERTY(opt_type)) {
+        return g_strdup_printf("%d (ms)", srv->client_idle_timeout);
+    }
+    if(CAN_SAVE_OPTS_PROPERTY(opt_type)) {
+        if(srv->client_idle_timeout == 8 * HOURS) {
+            return NULL;
+        }
+        return g_strdup_printf("%d", srv->client_idle_timeout);
+    }
+    return NULL;
+}
+
+gint
+assign_default_client_idle_timeout(const gchar *newval, gpointer param) {
+    gint ret = ASSIGN_ERROR;
+    struct external_param *opt_param = (struct external_param *)param;
+    chassis *srv = opt_param->chas;
+    gint opt_type = opt_param->opt_type;
+    if(CAN_ASSIGN_OPTS_PROPERTY(opt_type)) {
+        if(NULL != newval) {
+            int value = 0;
+            if(try_get_int_value(newval, &value)) {
+                if(value >= 0) {
+                    srv->client_idle_timeout = value;
                     ret = ASSIGN_OK;
                 } else {
                     ret = ASSIGN_VALUE_INVALID;

--- a/src/chassis-options-utils.h
+++ b/src/chassis-options-utils.h
@@ -79,6 +79,7 @@ CHASSIS_API gchar* show_check_slave_delay(gpointer param);
 CHASSIS_API gchar* show_slave_delay_down(gpointer param);
 CHASSIS_API gchar* show_slave_delay_recover(gpointer param);
 CHASSIS_API gchar* show_default_query_cache_timeout(gpointer param);
+CHASSIS_API gchar* show_default_client_idle_timeout(gpointer param);
 CHASSIS_API gchar* show_long_query_time(gpointer param);
 CHASSIS_API gchar* show_enable_client_found_rows(gpointer param);
 CHASSIS_API gchar* show_reduce_connections(gpointer param);
@@ -104,6 +105,7 @@ CHASSIS_API gint assign_max_header_size(const gchar *newval, gpointer param);
 CHASSIS_API gint assign_slave_delay_recover(const gchar *newval, gpointer param);
 CHASSIS_API gint assign_slave_delay_down(const gchar *newval, gpointer param);
 CHASSIS_API gint assign_default_query_cache_timeout(const gchar *newval, gpointer param);
+CHASSIS_API gint assign_default_client_idle_timeout(const gchar *newval, gpointer param);
 CHASSIS_API gint assign_long_query_time(const gchar *newval, gpointer param);
 CHASSIS_API gint assign_max_allowed_packet(const gchar *newval, gpointer param);
 


### PR DESCRIPTION
增加选项default-client-idle-timeout，以支持客户端的空闲超时设置