### PR TITLE
Add option for xa commit or xa rollback read timeout setting

### DIFF
--- a/plugins/proxy/proxy-plugin.c
+++ b/plugins/proxy/proxy-plugin.c
@@ -2556,12 +2556,12 @@ network_mysqld_proxy_plugin_get_options(chassis_plugin_config *config)
 
     chassis_options_add(&opts, "proxy-read-timeout",
                         0, 0, OPTION_ARG_DOUBLE, &(config->read_timeout_dbl),
-                        "read timeout in seconds (default: 10 minuates)", NULL,
+                        "read timeout in seconds (default: 10 minutes)", NULL,
                         assign_proxy_read_timeout, show_proxy_read_timeout, ALL_OPTS_PROPERTY);
 
     chassis_options_add(&opts, "proxy-write-timeout",
                         0, 0, OPTION_ARG_DOUBLE, &(config->write_timeout_dbl),
-                        "write timeout in seconds (default: 10 minuates)", NULL,
+                        "write timeout in seconds (default: 10 minutes)", NULL,
                         assign_proxy_write_timeout, show_proxy_write_timeout, ALL_OPTS_PROPERTY);
 
     chassis_options_add(&opts, "proxy-allow-ip",


### PR DESCRIPTION
读超时，根据不同情况不同对待，对于xa commit或者xa rollback，读超时可以根据需要灵活设置